### PR TITLE
Compiling error fixed

### DIFF
--- a/module/tx.c
+++ b/module/tx.c
@@ -95,7 +95,7 @@ static ssize_t device_write (struct file *filp, const char *buff, size_t len, lo
 	if (!tx) return 0;
 
 	/* copy userspace data to kernelspace */
-	r = copy_from_user (&tx->chan, buff, len);
+	r = raw_copy_from_user (&tx->chan, buff, len);
 
 	/* report new values to joystick device */
 	input_report_abs (tx->input_dev, ABS_X, tx->chan[0]);


### PR DESCRIPTION
Just tried to compile on ubuntu and got the following error:
```
make -C /lib/modules/4.15.0-46-generic/build M=/home/eric/txppm/module modules
make[1]: Entering directory '/usr/src/linux-headers-4.15.0-46-generic'
  CC [M]  /home/eric/txppm/module/tx.o
/home/eric/txppm/module/tx.c: In function ‘device_write’:
/home/eric/txppm/module/tx.c:98:6: error: implicit declaration of function ‘copy_from_user’; did you mean ‘raw_copy_from_user’? [-Werror=implicit-function-declaration]
  r = copy_from_user (&tx->chan, buff, len);
      ^~~~~~~~~~~~~~
      raw_copy_from_user
cc1: some warnings being treated as errors
scripts/Makefile.build:339: recipe for target '/home/eric/txppm/module/tx.o' failed
make[2]: *** [/home/eric/txppm/module/tx.o] Error 1
Makefile:1551: recipe for target '_module_/home/eric/txppm/module' failed
make[1]: *** [_module_/home/eric/txppm/module] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-4.15.0-46-generic'
Makefile:6: recipe for target 'all' failed 

```
.. fixed with this commit.